### PR TITLE
Replace "threashold" with "threshold" everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Flags:
   -n, --name string        Name of mosaic
       --out string         File to write final mosaic image
   -s, --size int           Number of mosaic partials in smallest dimension, 0 auto-calculates
-  -t, --threashold float   How similar aspect ratios must be (default -1)
+  -t, --threshold float    How similar aspect ratios must be (default -1)
   -w, --width int          Pixel width of mosaic, 0 maintains aspect from image height
 
 Global Flags:
@@ -219,7 +219,7 @@ Global Flags:
     The number and size of the partials in the other dimension would be determined by the aspect ratio of the mosaic partials.
   </dd>
 
-  <dt>--threashold</dt>
+  <dt>--threshold</dt>
   <dd>
     How similar aspect ratios must be. Allows you to filter out index images whose aspect ratio varies greatly from the aspect ratio of the mosaic partial.
     Threashold must be larger than the absolute value of the difference between the index ratio and the mosaic partial ratio, or the index image is excluded from the mosaic.
@@ -273,7 +273,7 @@ Flags:
   -n, --name string        Name of mosaic
   -o, --out string         File to write final mosaic image
   -s, --size int           Number of times to split the partials into quads (default -1)
-  -t, --threashold float   How similar aspect ratios must be (default -1)
+  -t, --threshold float    How similar aspect ratios must be (default -1)
   -w, --width int          Pixel width of mosaic, 0 maintains aspect from image height
 
 Global Flags:
@@ -349,7 +349,7 @@ Global Flags:
     The higher this value, the more uniformly small each mosaic partial will be in the result.
   </dd>
 
-  <dt>--threashold</dt>
+  <dt>--threshold</dt>
   <dd>
     How similar aspect ratios must be. Allows you to filter out index images whose aspect ratio varies greatly from the aspect ratio of the mosaic partial.
     Threashold must be larger than the absolute value of the difference between the index ratio and the mosaic partial ratio, or the index image is excluded from the mosaic.

--- a/cmd/mosaic_aspect.go
+++ b/cmd/mosaic_aspect.go
@@ -32,7 +32,7 @@ func init() {
 	addLocalStrFlag(&mosaicAspectPartialAspect, "aspect", "a", "", "Aspect of mosaic partials (CxR)", MosaicAspectCmd)
 	addLocalIntFlag(&mosaicAspectSize, "size", "s", 0, "Number of mosaic partials in smallest dimension, 0 auto-calculates", MosaicAspectCmd)
 	addLocalIntFlag(&mosaicAspectMaxRepeats, "max-repeats", "", -1, "Number of times an index image can be repeated, 0 is unlimited, -1 is the minimun number", MosaicAspectCmd)
-	addLocalFloatFlag(&mosaicAspectThreashold, "threashold", "t", -1.0, "How similar aspect ratios must be", MosaicAspectCmd)
+	addLocalFloatFlag(&mosaicAspectThreashold, "threshold", "t", -1.0, "How similar aspect ratios must be", MosaicAspectCmd)
 	addLocalStrFlag(&mosaicAspectOutfile, "out", "", "", "File to write final mosaic image", MosaicAspectCmd)
 	addLocalStrFlag(&mosaicAspectCoverOutfile, "cover-out", "", "", "File to write cover partial pattern image", MosaicAspectCmd)
 	addLocalStrFlag(&mosaicAspectMacroOutfile, "macro-out", "", "", "File to write resized macro image", MosaicAspectCmd)

--- a/cmd/mosaic_quad.go
+++ b/cmd/mosaic_quad.go
@@ -35,7 +35,7 @@ func init() {
 	addLocalIntFlag(&mosaicQuadMinArea, "min-area", "", -1, "The smallest a partial can get before it can't be split", MosaicQuadCmd)
 	addLocalIntFlag(&mosaicQuadMaxArea, "max-area", "", -1, "The largest a partial can be", MosaicQuadCmd)
 	addLocalIntFlag(&mosaicQuadMaxRepeats, "max-repeats", "", -1, "Number of times an index image can be repeated, 0 is unlimited, -1 is the minimun number", MosaicQuadCmd)
-	addLocalFloatFlag(&mosaicQuadThreashold, "threashold", "t", -1.0, "How similar aspect ratios must be", MosaicQuadCmd)
+	addLocalFloatFlag(&mosaicQuadThreashold, "threshold", "t", -1.0, "How similar aspect ratios must be", MosaicQuadCmd)
 	addLocalStrFlag(&mosaicQuadOutfile, "out", "o", "", "File to write final mosaic image", MosaicQuadCmd)
 	addLocalStrFlag(&mosaicQuadCoverOutfile, "cover-out", "", "", "File to write cover partial pattern image", MosaicQuadCmd)
 	addLocalStrFlag(&mosaicQuadMacroOutfile, "macro-out", "", "", "File to write resized macro image", MosaicQuadCmd)

--- a/cmd/partial_aspect.go
+++ b/cmd/partial_aspect.go
@@ -12,7 +12,7 @@ var (
 
 func init() {
 	addLocalIntFlag(&partialAspectMacroId, "macro-id", "", 0, "Id of macro to build partials", PartialAspectCmd)
-	addLocalFloatFlag(&partialAspectThreashold, "threashold", "t", -1.0, "How similar aspect ratios must be", PartialAspectCmd)
+	addLocalFloatFlag(&partialAspectThreashold, "threshold", "t", -1.0, "How similar aspect ratios must be", PartialAspectCmd)
 	RootCmd.AddCommand(PartialAspectCmd)
 }
 

--- a/controller/mosaic_aspect.go
+++ b/controller/mosaic_aspect.go
@@ -8,7 +8,7 @@ import (
 func MosaicAspect(env environment.Environment,
 	inPath, name, fillType string,
 	coverWidth, coverHeight, partialWidth, partialHeight, size, maxRepeats int,
-	threashold float64,
+	threshold float64,
 	coverOutfile, macroOutfile, mosaicOutfile string,
 	cleanup, destructive bool) *model.Mosaic {
 
@@ -24,7 +24,7 @@ func MosaicAspect(env environment.Environment,
 		return nil
 	}
 
-	err = PartialAspect(env, macro.Id, threashold)
+	err = PartialAspect(env, macro.Id, threshold)
 	if err != nil {
 		return nil
 	}

--- a/controller/mosaic_quad.go
+++ b/controller/mosaic_quad.go
@@ -8,7 +8,7 @@ import (
 func MosaicQuad(env environment.Environment,
 	inPath, name, fillType string,
 	coverWidth, coverHeight, size, minDepth, maxDepth, minArea, maxArea, maxRepeats int,
-	threashold float64,
+	threshold float64,
 	coverOutfile, macroOutfile, mosaicOutfile string,
 	cleanup, destructive bool) *model.Mosaic {
 
@@ -24,7 +24,7 @@ func MosaicQuad(env environment.Environment,
 		return nil
 	}
 
-	err = PartialAspect(env, macro.Id, threashold)
+	err = PartialAspect(env, macro.Id, threshold)
 	if err != nil {
 		return nil
 	}

--- a/controller/partial_aspect.go
+++ b/controller/partial_aspect.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/cheggaaa/pb.v1"
 )
 
-func PartialAspect(env environment.Environment, macroId int64, threashold float64) error {
+func PartialAspect(env environment.Environment, macroId int64, threshold float64) error {
 	aspectService := env.ServiceFactory().MustAspectService()
 	macroService := env.ServiceFactory().MustMacroService()
 	macroPartialService := env.ServiceFactory().MustMacroPartialService()
@@ -37,7 +37,7 @@ func PartialAspect(env environment.Environment, macroId int64, threashold float6
 		return err
 	}
 
-	err = createPartialGidxIndexes(env, aspects, threashold, env.Workers())
+	err = createPartialGidxIndexes(env, aspects, threshold, env.Workers())
 	if err != nil {
 		env.Printf("Error creating index aspects: %s\n", err.Error())
 		return err
@@ -46,7 +46,7 @@ func PartialAspect(env environment.Environment, macroId int64, threashold float6
 	return nil
 }
 
-func createPartialGidxIndexes(env environment.Environment, aspects []*model.Aspect, threashold float64, workers int) error {
+func createPartialGidxIndexes(env environment.Environment, aspects []*model.Aspect, threshold float64, workers int) error {
 	gidxService := env.ServiceFactory().MustGidxService()
 	gidxPartialService := env.ServiceFactory().MustGidxPartialService()
 
@@ -78,7 +78,7 @@ func createPartialGidxIndexes(env environment.Environment, aspects []*model.Aspe
 				return errors.New("Cancelled")
 			}
 
-			gidxPartials, err := buildGidxPartials(env, gidx, aspects, threashold, workers)
+			gidxPartials, err := buildGidxPartials(env, gidx, aspects, threshold, workers)
 			if err != nil {
 				return err
 			}
@@ -96,17 +96,17 @@ func createPartialGidxIndexes(env environment.Environment, aspects []*model.Aspe
 	return nil
 }
 
-func buildGidxPartials(env environment.Environment, gidx *model.Gidx, aspects []*model.Aspect, threashold float64, workers int) ([]*model.GidxPartial, error) {
+func buildGidxPartials(env environment.Environment, gidx *model.Gidx, aspects []*model.Aspect, threshold float64, workers int) ([]*model.GidxPartial, error) {
 	gidxPartialService := env.ServiceFactory().MustGidxPartialService()
 
 	var gidxPartials []*model.GidxPartial
 
 	pAspects := []*model.Aspect{}
-	if threashold < 0.0 {
+	if threshold < 0.0 {
 		pAspects = aspects
 	} else {
 		for _, aspect := range aspects {
-			if gidx.Within(threashold, aspect) {
+			if gidx.Within(threshold, aspect) {
 				pAspects = append(pAspects, aspect)
 			}
 		}

--- a/model/gidx.go
+++ b/model/gidx.go
@@ -12,7 +12,7 @@ type Gidx struct {
 	Orientation int    `db:"orientation"`
 }
 
-func (gidx *Gidx) Within(threashold float64, aspect *Aspect) bool {
+func (gidx *Gidx) Within(threshold float64, aspect *Aspect) bool {
 	gRatio := float64(gidx.Width) / float64(gidx.Height)
 	aRatio := aspect.Ratio()
 
@@ -20,7 +20,7 @@ func (gidx *Gidx) Within(threashold float64, aspect *Aspect) bool {
 		return true
 	}
 
-	return math.Abs(gRatio-aRatio) <= threashold
+	return math.Abs(gRatio-aRatio) <= threshold
 }
 
 // implement Image interface


### PR DESCRIPTION
Hi there,

This looks like a very cool project! I just found this on Reddit, read over the readme and caught a typo, so I figured I'd send a PR.

I ran `find . -type f -exec sed -i 's/threashold/threshold/g' {} \+`
then added one space to two lines in `README.md` to fix indentation

Cheers,
Oliver 